### PR TITLE
Valid SPDX license string for package/bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "amd",
     "es6"
   ],
-  "license": "GPLv2",
+  "license": "GPL-2.0",
   "private": true,
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git://github.com/mwcz/Kimotion.git"
   },
   "author": "mwcz palebluepixel.org",
-  "license": "GPLv2",
+  "license": "GPL-2.0",
   "bugs": {
     "url": "https://github.com/mwcz/Kimotion/issues"
   },


### PR DESCRIPTION
While running npm install, I got a message about an invalid license string, so I put in the GPL2 string from https://spdx.org/licenses/
